### PR TITLE
chore(cambricon): build cambricon converter automaticaly

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,29 +65,42 @@ MgeConvert前端的部分都在`mge_context`目录下, 可以直接将MegEngine 
 
 * 寒武纪转换器
 
-  寒武纪转换器目前支持的硬件平台仅包括MLU270智能加速卡系列，使用前请事先安装MLU270智能加速卡和配套SDK，SDK版本需在1.2.5以上。更多信息请联系寒武纪。
-  安装camke、swig和python-dev
+  寒武纪转换器目前支持的硬件平台仅包括MLU270智能加速卡系列，使用前请事先安装MLU270智能加速卡和配套SDK并配置好安装路径 `NEUWARE_HOME=/path/to/cambricon`。SDK版本需在1.2.5以上，更多信息请联系寒武纪。
+
+  安装cmake、swig和python-dev
+
   ```bash
   sudo apt install cmake swig python3-dev
   ```
+
+  以下两个步骤将在安装本仓库时自动执行。
+
   从numpy官方库下载`numpy.i`，并放入路径`mgeconvert/cambricon_converter/swig`中。
+
   ```bash
-  wget -P mgeconvert/cambricon_converter/swig https://raw.githubusercontent.com/numpy/numpy/master/tools/swig/numpy.i
+  wget -P mgeconvert/cambricon_converter/swig \
+  https://raw.githubusercontent.com/numpy/numpy/master/tools/swig/numpy.i
   ```
-  编译得到python接口，执行以下命令前需要设置寒武纪环境变量。`NEUWARE_HOME=/path/to/cambricon`
-  ```
+
+  编译得到python接口。
+
+  ```bash
   cd mgeconvert/cambricon_converter
   mkdir build && cd build
   cmake ..
   make && make develop
   ```
+
   [测试用例](test/test_cambricon.py) 中可以完成相应的转换测试，[子目录](mgeconvert/cambricon_converter/README.md)获取更多寒武纪转换器相关信息。
 
 ### MgeConvert安装
-使用setup.py安装MgeConvert
+
+使用setup.py安装MgeConvert。
+
+默认不会安装寒武纪转换器，否则请先设置环境变量 `export USE_CAMBRICON_CONVERTER=ON`。
+
 ```bash
-python3 setup.py build
-python3 setup.py install
+pip3 install .
 ```
 
 ## 转换器使用说明

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 import glob
 import os
 import re
+import subprocess
 
-from setuptools import Extension as _Extension
-from setuptools import find_packages, setup
+from setuptools import Extension, find_packages, setup
+from setuptools.command.build_ext import build_ext
 
 with open(os.path.join("./mgeconvert", "version.py")) as f:
     __version_py__ = f.read()
@@ -13,26 +14,55 @@ MEGENGINE_LOWER = re.search(r"MEGENGINE_LOWER = \"(.*)\"", __version_py__).group
 __version__ = re.search(r"__version__ = \"(.*)\"", __version_py__).group(1)
 
 
-class Extension(_Extension):
-    def __init__(self, *a, include_dirs=None, **kw):
-        super(Extension, self).__init__(*a, **kw)
-        self._include_dirs = include_dirs or []
+class CMakeExtension(Extension):
+    def __init__(self, name, source_dir, lib_dir, products):
+        super().__init__(name, sources=[])
+        self.source_dir = source_dir
+        self.lib_dir = os.path.join(source_dir, lib_dir)
+        self.products = products
 
-    """
-    Here we make `include_dirs` an property to make it an deferred attibute,
-    so the `numpy` package can be installed via `setup_requires`, and imported
-    in this property.
-    """
 
-    @property
-    def include_dirs(self):
-        import numpy as np
+class cmake_build_ext(build_ext):
+    def run(self):
+        for ext in self.extensions:
+            try:
+                self.build_cmake(ext)
+            except subprocess.CalledProcessError:
+                continue
 
-        return self._include_dirs + [np.get_include()]
+    def build_cmake(self, ext):
+        source_dir = os.path.abspath(ext.source_dir)
 
-    @include_dirs.setter
-    def include_dirs(self, value):
-        self._include_dirs = value
+        if not os.path.exists(self.build_temp):
+            os.makedirs(self.build_temp)
+
+        path = os.path.join(source_dir, "swig", "numpy.i")
+        url = "https://raw.githubusercontent.com/numpy/numpy/master/tools/swig/numpy.i"
+        if not os.path.exists(path):
+            subprocess.check_call(["wget", "-P", os.path.dirname(path), url])
+
+        subprocess.check_call(["cmake", source_dir], cwd=self.build_temp)
+        subprocess.check_call(["cmake", "--build", "."], cwd=self.build_temp)
+
+        for product in ext.products:
+            source_file = os.path.join(self.build_temp, product)
+            dest_file = os.path.join(self.build_lib, ext.lib_dir, product)
+            self.copy_file(source_file, dest_file)
+
+
+if os.getenv("USE_CAMBRICON_CONVERTER"):
+    ext_modules = [
+        CMakeExtension(
+            name="_cambriconLib",
+            source_dir="mgeconvert/cambricon_converter",
+            lib_dir="lib/cnlib",
+            products=["_cambriconLib.so", "cambriconLib.py"],
+        )
+    ]
+    cmdclass = {"build_ext": cmake_build_ext}
+else:
+    ext_modules = []
+    cmdclass = {}
 
 
 setup(
@@ -43,6 +73,8 @@ setup(
     author_email="brain-engine@megvii.com",
     url="https://github.com/MegEngine/mgeconvert",
     packages=find_packages(exclude=["test", "test.*"]),
+    ext_modules=ext_modules,
+    cmdclass=cmdclass,
     include_package_data=True,
     setup_requires=["Cython >= 0.20", "numpy"],
     install_requires=["megengine >={}".format(MEGENGINE_LOWER), "numpy"],

--- a/test/test_caffe.py
+++ b/test/test_caffe.py
@@ -154,7 +154,13 @@ def test_model(model):
         .reshape((1, 3, 224, 224))
         .astype(np.float32)
     )
-    net = megengine.hub.load("megengine/models", model, pretrained=True)
+    if megengine.__version__ < "1.1.0":
+        commit_id = "dc2f2cfb228a135747d083517b98aea56e7aab92"
+    else:
+        commit_id = None
+    net = megengine.hub.load(
+        "megengine/models", model, use_cache=False, commit=commit_id, pretrained=True
+    )
     mge_result = dump_mge_model(net, data, tmp_file)
     _test_convert_result(data, tmp_file, mge_result, 1e-2)
 

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -149,7 +149,13 @@ def test_model(model):
         .reshape((1, 3, 224, 224))
         .astype(np.float32)
     )
-    net = megengine.hub.load("megengine/models", model, pretrained=True)
+    if megengine.__version__ < "1.1.0":
+        commit_id = "dc2f2cfb228a135747d083517b98aea56e7aab92"
+    else:
+        commit_id = None
+    net = megengine.hub.load(
+        "megengine/models", model, use_cache=False, commit=commit_id, pretrained=True
+    )
     mge_result = dump_mge_model(net, data, tmp_file)
     _test_convert_result(data, tmp_file, mge_result, 1e-3)
 


### PR DESCRIPTION
在 `pip3 install .` 的时候完成寒武纪转换器的编译。
现在的默认行为是不装寒武纪转换器，也不需要管寒武纪的环境。
如果想要寒武纪，可以设置环境变量 `USE_CAMBRICON_CONVERTER=ON`，然后再 `pip3 install .`
@lixiangyin666 @dingshaohua960303 