### PR TITLE
Support more ops for converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ MgeConvert前端的部分都在`mge_context`目录下, 可以直接将MegEngine 
 |reshape| ✓ | ✓ | ✓ | ✓ |
 |sigmoid| ✓ | ✓ | ✓ | × |
 |softmax| ✓ | ✓ | ✓ | ✓ |
+|leaky_relu| ✓ | × | × | ✓ |
 |sub| ✓ | ✓ | ✓ | ✓ |
 |slice(subtensor)| ✓ | ✓ | ✓ | × |
 |squeeze(axis_add_remove)| ✓ | ✓ | ✓ | × |
@@ -100,11 +101,11 @@ MgeConvert前端的部分都在`mge_context`目录下, 可以直接将MegEngine 
 
 * TFLite 转换器
 
-TFLite 使用 flatbuffer 作为序列化格式，并且为了支持 mtk 平台需要自定义一些序列化格式，就需要封装 flexbuffer 的接口。可使用如下命令进行软件安装和相关配置：
+  TFLite 使用 flatbuffer 作为序列化格式，并且为了支持 mtk 平台需要自定义一些序列化格式，就需要封装 flexbuffer 的接口。可使用如下命令进行软件安装和相关配置：
 
-```bash
-./mgeconvert/tflite_converter/init.sh
-```
+  ```bash
+  ./mgeconvert/tflite_converter/init.sh
+  ```
 
 ### MgeConvert安装
 

--- a/ci/pytest_tflite.sh
+++ b/ci/pytest_tflite.sh
@@ -11,17 +11,17 @@ sudo python3 -m pip uninstall flatbuffers -y
 sudo python3 -m pip install tensorflow==2.4.0
 
 sudo -H python3 -m pip install -q megengine==1.2.0 -f https://megengine.org.cn/whl/mge.html
-pytest test/test_tflite.py
+pytest -v test/test_tflite.py
 sudo -H python3 -m pip uninstall -y megengine
 
 sudo -H python3 -m pip install -q megengine==1.1.0 -f https://megengine.org.cn/whl/mge.html
-pytest test/test_tflite.py
+pytest -v test/test_tflite.py
 sudo -H python3 -m pip uninstall -y megengine
 
 sudo -H python3 -m pip install -q megengine==1.0.0 -f https://megengine.org.cn/whl/mge.html
-pytest test/test_tflite.py
+pytest -v test/test_tflite.py
 sudo -H python3 -m pip uninstall -y megengine
 
 sudo -H python3 -m pip install -q megengine==0.6.0 -f https://megengine.org.cn/whl/mge.html
-pytest test/test_tflite.py
+pytest -v test/test_tflite.py
 sudo -H python3 -m pip uninstall -y megengine

--- a/mgeconvert/caffe_converter/caffe_converter.py
+++ b/mgeconvert/caffe_converter/caffe_converter.py
@@ -8,6 +8,7 @@
 # "AS IS" BASIS, WITHOUT ARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import numpy as np
 from google.protobuf import text_format  # type: ignore[attr-defined]
+from tqdm import tqdm
 
 from ..mge_context import TopologyNetwork
 from ..mge_context import mge_op as Op
@@ -306,7 +307,7 @@ class CaffeConverter:
             if all_oprs[index].skip:
                 del all_oprs[index]
 
-        for opr in all_oprs:
+        for opr in tqdm(all_oprs):
             if not need_convert(opr):
                 for tensor in opr.out_vars:
                     if tensor.np_data is None:

--- a/mgeconvert/caffe_converter/caffe_op.py
+++ b/mgeconvert/caffe_converter/caffe_op.py
@@ -891,11 +891,12 @@ def _reduce(opr, context):
         "SUM",
         "MAX",
         "SUM_SQR",
+        "MEAN",
     ], "Reduce op doesn't support mode {}, you can implement it in _reduce".format(
         opr.mode
     )
-    if opr.mode == "SUM" or opr.mode == "SUM_SQR":
-        mode = "SUM"
+    if opr.mode in ("SUM", "SUM_SQR", "MEAN"):
+        mode = opr.mode
         if opr.mode == "SUM_SQR":
             mode = "SUMSQ"
         bottom = [context.get_blob_name(opr.inp_vars[0])]

--- a/mgeconvert/tflite_converter/init.sh
+++ b/mgeconvert/tflite_converter/init.sh
@@ -8,7 +8,7 @@ sudo rm -rf /usr/local/lib/libflatbuffers*
 # build flatbuffers
 echo "building flatbuffers..."
 sudo rm -rf /tmp/flatbuffers
-git clone https://github.com/google/flatbuffers.git /tmp/flatbuffers
+git clone https://github.com/google/flatbuffers.git -b v1.12.0 /tmp/flatbuffers
 cd /tmp/flatbuffers
 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_SHAREDLIB=on -DCMAKE_INSTALL_PREFIX=/usr/local
 make -j; sudo make install

--- a/mgeconvert/tflite_converter/tflite_converter.py
+++ b/mgeconvert/tflite_converter/tflite_converter.py
@@ -64,6 +64,7 @@ class TFLiteConverter:
             TransformerRule.MAKE_PADDING,
             TransformerRule.FUSE_ASTYPE,
             TransformerRule.TRANSPOSE_PATTERN_AS_INPUT,
+            TransformerRule.FUSE_FOR_LEAKY_RELU,
             TransformerRule.EXPAND_MUL_ADD3,
             TransformerRule.EXPAND_ADD_SIGMOID,
         ]
@@ -89,7 +90,6 @@ class TFLiteConverter:
             return not all(is_const) or len(mge_opr.inp_vars) == 0
 
         for mge_opr in tqdm(self.net.all_oprs):
-            print(">>", mge_opr.name)
             last_opr = mge_opr
             if not need_convert(mge_opr):
                 continue
@@ -107,7 +107,6 @@ class TFLiteConverter:
 
                 result_shape, byte_list = get_shape_param(var, mge_opr, disable_nhwc)
                 var.shape = result_shape
-                print("    ##", var.name, var.shape)
 
                 scale = None
                 zero_point = 0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
-filterwarnings =
-    ignore::DeprecationWarning
+addopts = -p no:warnings

--- a/test/test_caffe.py
+++ b/test/test_caffe.py
@@ -143,7 +143,7 @@ def test_active(mode):
     _test_convert_result(net.data, tmp_file, mge_result, max_error)
 
 
-@pytest.mark.parametrize("mode", ["max", "sum"])
+@pytest.mark.parametrize("mode", ["max", "sum", "mean"])
 def test_reduce(mode):
     net = ReduceOpr(mode)
     mge_result = dump_mge_model(net, net.data, tmp_file)

--- a/test/test_tflite.py
+++ b/test/test_tflite.py
@@ -144,7 +144,7 @@ def test_reduce(mode):
     _test_convert_result(net.data, tmp_file, mge_result, max_error)
 
 
-@pytest.mark.parametrize("mode", ["relu", "softmax", "relu6"])
+@pytest.mark.parametrize("mode", ["relu", "softmax", "relu6", "leaky_relu"])
 def test_active(mode):
     net = ActiveOpr(mode, fused=True)
     mge_result = dump_mge_model(net, net.data, tmp_file)

--- a/test/test_tflite.py
+++ b/test/test_tflite.py
@@ -137,8 +137,10 @@ def test_elemwise_broadcast(mode):
     )
 
 
-@pytest.mark.parametrize("mode", ["max", "sum"])
+@pytest.mark.parametrize("mode", ["max", "sum", "mean"])
 def test_reduce(mode):
+    if mode == "mean" and megengine.__version__ < "1.0.0":
+        return
     net = ReduceOpr(mode)
     mge_result = dump_mge_model(net, net.data, tmp_file)
     _test_convert_result(net.data, tmp_file, mge_result, max_error)

--- a/test/utils.py
+++ b/test/utils.py
@@ -286,6 +286,8 @@ class ReduceOpr(M.Module):
     def forward(self, a):
         if self.mode == "sum":
             return F.sum(a, axis=2)
+        elif self.mode == "mean":
+            return F.mean(a, axis=2)
         else:
             return F.max(a, axis=2)
 


### PR DESCRIPTION
1. tflite 依赖的 flatbuffers 版本固定了一下
2. tflite 增加 leaky_relu
3. caffe 增加 reduce mean

caffe pooling 是有可能出现 slice op，但那个应该不是bug，是计算方式不一致导致必须对输出做裁剪。

@lixiangyin666 @xpmemeda  pls kindly review.