### PR TITLE
fix(onnx): fix reduce op

### DIFF
--- a/mgeconvert/onnx_converter/onnx_op.py
+++ b/mgeconvert/onnx_converter/onnx_op.py
@@ -504,6 +504,14 @@ class ReduceConverter(OperatorBaseConverter):
     def _get_attrs(self):
         return {"axes": [self._opr.axis]}
 
+    def convert(self):
+        inputs = self._get_inputs()
+        outputs = self._get_outputs()
+        nodes = onnx.helper.make_node(
+            self.__opr_type__, [inputs[0]], outputs, **self._get_attrs()
+        )
+        return [nodes], self._net_sources, self._parameters
+
 
 @_register_op(AxisAddRemoveOpr)
 class AxisAddRemoveConverter(OperatorBaseConverter):


### PR DESCRIPTION
支持 Reduce Op 有两个输入的情况，第二个输入是 target_shape，但是在转到 onnx reduce 时并没有用到。

@dingshaohua960303 