### PR TITLE
feat(megconvert/caffe): add reoreder outputs method for caffe converter

### DIFF
--- a/mgeconvert/backend/ir_to_caffe/caffe_converter.py
+++ b/mgeconvert/backend/ir_to_caffe/caffe_converter.py
@@ -15,7 +15,7 @@ from megengine import get_logger
 from tabulate import tabulate
 from tqdm import tqdm
 
-from ...converter_ir.ir_graph import IRGraph
+from ...converter_ir.ir_graph import IRGraph, OpBase
 from ...converter_ir.ir_quantizer import IRQuantizer
 from ...converter_ir.ir_tensor import IRTensor  # pylint: disable=unused-import
 from .caffe_op import MGE2CAFFE, BackEnd, _add_input_layer

--- a/mgeconvert/converter_ir/ir_transform.py
+++ b/mgeconvert/converter_ir/ir_transform.py
@@ -1019,12 +1019,15 @@ def fold_conv_bn(
 @_register_tranformation_rule(TransformerRule.FUSE_CONV_BN)
 def _fuse_conv_bn(net: IRGraph):
     for opr in net.all_oprs:
+        inp_oprs = net.find_inp_oprs(opr)
+        if opr.name != "BatchNormalization":
+            continue
         if (
-            opr.name == "BatchNormalization"
-            and len(net.find_inp_oprs(opr)) == 1
-            and net.find_inp_oprs(opr)[0].name == "Conv2d"
-            and len(net.find_out_oprs(net.find_inp_oprs(opr)[0])) == 1
-            and net.find_out_oprs(net.find_inp_oprs(opr)[0])[0] == opr
+            len(inp_oprs) == 1
+            and isinstance(inp_oprs[0], OpBase)
+            and inp_oprs[0].name == "Conv2d"
+            and len(net.find_out_oprs(inp_oprs[0])) == 1
+            and net.find_out_oprs(inp_oprs[0])[0] == opr
         ):
             gamma = (
                 Tensor(opr.weight)  # type: ignore[attr-defined]

--- a/mgeconvert/converters/tm_to_caffe.py
+++ b/mgeconvert/converters/tm_to_caffe.py
@@ -67,8 +67,6 @@ def tracedmodule_to_caffe(
         TransformerRule.REMOVE_UNRELATED_IROP,
         TransformerRule.ADD_FAKE_HSIGMOID_OUT,
         TransformerRule.EXPAND_CONVRELU,
-        TransformerRule.CONV_ADD_ZERO_BIAS,
-        TransformerRule.FUSE_CONV_BN,
     ]
     if split_conv_relu:
         transformer_options += [TransformerRule.REMOVE_RELU]

--- a/mgeconvert/converters/tm_to_caffe.py
+++ b/mgeconvert/converters/tm_to_caffe.py
@@ -67,6 +67,8 @@ def tracedmodule_to_caffe(
         TransformerRule.REMOVE_UNRELATED_IROP,
         TransformerRule.ADD_FAKE_HSIGMOID_OUT,
         TransformerRule.EXPAND_CONVRELU,
+        TransformerRule.CONV_ADD_ZERO_BIAS,
+        TransformerRule.FUSE_CONV_BN,
     ]
     if split_conv_relu:
         transformer_options += [TransformerRule.REMOVE_RELU]


### PR DESCRIPTION
给 caffe converter 添加对输出 layer 重排序的方法。

根据 IR graph 中的的输出 IRTensor 的顺序，重新对 caffe 的输出 layer 排序。