### PR TITLE
fix(mgeconvert/tflite): fix depth_multiplier of depthwise conv

### DIFF
--- a/mgeconvert/backend/ir_to_tflite/tflite_op.py
+++ b/mgeconvert/backend/ir_to_tflite/tflite_op.py
@@ -285,8 +285,13 @@ def _conv2d(mge_opr, builder):
         DepthwiseConv2DOptions.DepthwiseConv2DOptionsAddStrideW(
             builder, mge_opr.stride[1]
         )
+        assert isinstance(mge_opr.inp_tensors[1].axis_order, OIHWFormat)
+        assert isinstance(mge_opr.inp_tensors[0].axis_order, NCHWFormat)
+        num_filter_channels = mge_opr.inp_tensors[1].shape[0]
+        num_input_channels = mge_opr.inp_tensors[0].shape[1]
+        assert num_filter_channels % num_input_channels == 0
         DepthwiseConv2DOptions.DepthwiseConv2DOptionsAddDepthMultiplier(
-            builder, mge_opr.inp_tensors[1].shape[0]
+            builder, num_filter_channels // num_input_channels
         )
         DepthwiseConv2DOptions.DepthwiseConv2DOptionsAddFusedActivationFunction(
             builder, mge2tflite_activation_type[mge_opr.activation]

--- a/test/traced_module/test_tflite.py
+++ b/test/traced_module/test_tflite.py
@@ -96,10 +96,21 @@ def _test_convert_result(
         assert i.dtype == j.dtype
         atol = max_err if s == 1 else s
         np.testing.assert_allclose(i, j, atol=atol)
-    print("success!")
 
 
-@pytest.mark.parametrize("mode", ["normal", "group", "tflite_transpose"])
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "normal",
+        "group",
+        "tflite_transpose",
+        "same_pad",
+        "same_pad_1",
+        "same_pad_2",
+        "valid_pad",
+        "valid_pad_1",
+    ],
+)
 def test_conv(mode):
     net = ConvOpr(mode)
     data = mge.tensor(np.random.random((1, 3, 224, 224)).astype(np.float32))

--- a/test/utils.py
+++ b/test/utils.py
@@ -66,6 +66,12 @@ class ConvOpr(M.Module):
             3, 30, 3, stride=(2, 3), dilation=(2, 2), padding=(3, 1), groups=3
         )
 
+        self.valid_pad_conv = M.Conv2d(3, 30, 4, padding=(1, 1))
+        self.valid_pad_1_conv = M.Conv2d(3, 30, 3, stride=2, padding=(1, 1))
+        self.same_pad_conv = M.Conv2d(3, 30, 3, padding=(1, 1))
+        self.same_pad_1_conv = M.Conv2d(3, 30, 4, stride=2, padding=(1, 1))
+        self.same_pad_2_conv = M.Conv2d(3, 30, 2, dilation=3, stride=2, padding=(1, 1))
+
         self.normal_conv.bias = mge.Parameter(
             np.random.random(self.normal_conv.bias.shape).astype(np.float32)
         )


### PR DESCRIPTION
修复 depthwise conv depth_multiplier的转换， 具体计算方式参考 tflite kernel实现：https://github.com/tensorflow/tensorflow/blob/8933b8a21280696ab119b63263babdb54c298538/tensorflow/lite/kernels/depthwise_conv.cc#L292
depth_multiplier = num_filter_channels % num_input_channels

修复 conv/pool 等op转到tflite时 pad_mode的计算的实现， 旧版本判断 inp_shape == out_shape 时用SAME模式， 其他情况用VALID， 在部分 ceil(inp_shape/stride) == out_shape 的情况下也可以用SAME模式。 

https://github.com/tensorflow/tensorflow/blob/0b6b491d21d6a4eb5fbab1cca565bc1e94ca9543/tensorflow/core/framework/kernel_shape_util.cc#L35~L56

