### PR TITLE
fix mge conv weight axis order

### DIFF
--- a/mgeconvert/frontend/mge_to_ir/op_generators/convolution.py
+++ b/mgeconvert/frontend/mge_to_ir/op_generators/convolution.py
@@ -43,11 +43,11 @@ class GenConv2dOpr(OpGenBase):
         self.op.add_inp_tensors(
             self.resolver.get_ir_tensor(mge_opr.inputs[0], user_opr=self.op)
         )
-        self.op.add_inp_tensors(
-            self.resolver.get_ir_tensor(
-                mge_opr.inputs[1], user_opr=self.op, axis_order=AxisOrder.OIHW
-            )
+        weight_tensor = self.resolver.get_ir_tensor(
+            mge_opr.inputs[1], user_opr=self.op, axis_order=AxisOrder.OIHW
         )
+        weight_tensor.axis_order = AxisOrder.OIHW
+        self.op.add_inp_tensors(weight_tensor)
         if len(mge_opr.inputs) > 2:
             self.op.add_inp_tensors(
                 self.resolver.get_ir_tensor(mge_opr.inputs[2], user_opr=self.op)
@@ -90,11 +90,11 @@ class GenDeconv2dOpr(OpGenBase):
         self.op.add_inp_tensors(
             self.resolver.get_ir_tensor(mge_opr.inputs[1], user_opr=self.op)
         )
-        self.op.add_inp_tensors(
-            self.resolver.get_ir_tensor(
-                mge_opr.inputs[0], user_opr=self.op, axis_order=AxisOrder.IOHW
-            )
+        weight_tensor = self.resolver.get_ir_tensor(
+            mge_opr.inputs[0], user_opr=self.op, axis_order=AxisOrder.IOHW
         )
+        weight_tensor.axis_order = AxisOrder.IOHW
+        self.op.add_inp_tensors(weight_tensor)
         if len(mge_opr.inputs) > 2:
             self.op.add_inp_tensors(
                 self.resolver.get_ir_tensor(mge_opr.inputs[2], user_opr=self.op)


### PR DESCRIPTION
resolve [MGE-3791](https://jira.megvii-inc.com/browse/MGE-3791)。
mge模型 conv / deconv 的weight是 其他opr的输出，axis_order默认是NCHW，导致 cal_pad_mode 时检查不通过，这里需要重置一下。
@lixiangyin666 @dingshaohua960303 please review.