### PR TITLE
fix some bugs of mgeconvert

### DIFF
--- a/mgeconvert/backend/ir_to_caffe/caffe_converter.py
+++ b/mgeconvert/backend/ir_to_caffe/caffe_converter.py
@@ -131,8 +131,10 @@ class CaffeConverter:
         self.quantizer = quantizer
         self.convert_backend = convert_backend
 
-    def update_quantize_dict(self, tensor):
-        self.quantizer.parse_quant_info(tensor)
+    def update_quantize_dict(self, tensor, name=None):
+        if tensor.q_dtype is not None:
+            tname = name if name is not None else tensor.name
+            self.quantizer.set_quant_info(tname, tensor)
 
     def dump(self, proto_file, caffe_file=None):
         CaffeNet = cp.NetParameter(layer=self.layers)

--- a/mgeconvert/backend/ir_to_tflite/tflite_converter.py
+++ b/mgeconvert/backend/ir_to_tflite/tflite_converter.py
@@ -32,6 +32,7 @@ from .tflite_op import (
     get_shape_param,
     mge2tflite_dtype_mapping,
     set_quantization,
+    set_tensor_format,
 )
 
 
@@ -53,6 +54,10 @@ class TFLiteConverter:
 
     def convert(self, disable_nhwc=False):
         # Note the 0th entry of this array must be an empty buffer (sentinel)
+        if disable_nhwc:
+            set_tensor_format("nchw")
+        else:
+            set_tensor_format("nhwc")
         Buffer.BufferStart(self._builder)
         buffer = Buffer.BufferEnd(self._builder)
         self._buffer_list.append(buffer)
@@ -106,7 +111,7 @@ class TFLiteConverter:
                     )
 
                     if isinstance(dtype, QuantDtypeMeta):
-                        dtype = dtype.np_dtype_str
+                        dtype = dtype.name
                 else:
                     dtype = tensor.dtype
 

--- a/mgeconvert/backend/ir_to_tflite/tflite_op.py
+++ b/mgeconvert/backend/ir_to_tflite/tflite_op.py
@@ -426,9 +426,18 @@ def _deconv(mge_opr, builder):
 
 @_register_op(ConcatOpr)
 def _concat(mge_opr, builder):
-    if len(set([t.scale for t in mge_opr.inp_tensors + mge_opr.out_tensors])) != 1:
+    if (
+        mge_opr.inp_tensors[0].q_dtype == "int8"
+        and len({t.scale for t in mge_opr.inp_tensors + mge_opr.out_tensors}) != 1
+    ):
         logger.warning(
-            "tflite concat doesn't support inputs outputs with different scale!"
+            "tflite int8 concat doesn't support inputs outputs with different scale!"
+        )
+    if mge_opr.inp_tensors[0].q_dtype == "int16" and not all(
+        [t.zero_point == 0 for t in mge_opr.inp_tensors + mge_opr.out_tensors]
+    ):
+        logger.warning(
+            "tflite int16 concat doesn't support inputs outputs with zero point != 0!"
         )
 
     ConcatenationOptions.ConcatenationOptionsStart(builder)

--- a/mgeconvert/converter_ir/ir_tensor.py
+++ b/mgeconvert/converter_ir/ir_tensor.py
@@ -5,7 +5,7 @@
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT ARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-from typing import List, Sequence, Union
+from typing import List, Sequence
 
 
 class DataFormat:
@@ -94,7 +94,10 @@ class IRTensor:
         dtype,
         scale=None,
         zero_point=None,
+        qmin=None,
+        qmax=None,
         q_type=None,
+        np_dtype=None,
         np_data=None,
         owner_opr=None,
         axis=AxisOrder.NCHW,
@@ -110,7 +113,11 @@ class IRTensor:
 
         self.scale = scale
         self.zero_point = zero_point
+        self.qmin = qmin
+        self.qmax = qmax
+        assert isinstance(q_type, str) or q_type is None
         self.q_dtype = q_type
+        self.np_dtype = np_dtype
 
     @property
     def ndim(self):
@@ -123,9 +130,22 @@ class IRTensor:
         self.np_data = self.np_data.astype(target_type)
         self.dtype = target_type
 
-    def set_qparams(
-        self, scale: Union[float, List[float]], zero_point=None, q_dtype=None
-    ):
+    def set_qparams_from_other_tensor(self, other):
+        self.q_dtype = other.q_dtype
+        self.np_dtype = other.np_dtype
+        self.qmin = other.qmin
+        self.qmax = other.qmax
+        self.scale = other.scale
+        self.zero_point = other.zero_point
+
+    def set_qparams_from_mge_qparams(self, qparams):
+        dtype_meta = qparams.dtype_meta
+        self.q_dtype = dtype_meta.name
+        self.np_dtype = dtype_meta.np_dtype_str
+        self.qmin = dtype_meta.qmin
+        self.qmax = dtype_meta.qmax
+        scale = qparams.scale
+        zero_point = qparams.zero_point
         if not isinstance(scale, Sequence):  # per tensor
             self.scale = float(scale)
         else:  # per channel
@@ -137,8 +157,29 @@ class IRTensor:
             else:
                 self.zero_point = [int(zp) for zp in zero_point]
 
-        if self.q_dtype is not None:
-            self.q_dtype = q_dtype
+    def set_qparams(
+        self,
+        *,
+        scale: float,
+        q_dtype: str,
+        qmin: int = None,
+        qmax: int = None,
+        zero_point=None,
+        np_dtype=None,
+    ):
+        if qmin is None or qmax is None:
+            assert np_dtype is not None, "must provide np_dtype or qmin and qmax"
+        if not isinstance(scale, Sequence):  # per tensor
+            self.scale = float(scale)
+        else:  # per channel
+            self.scale = [float(s) for s in scale]
+        if zero_point is not None:
+            if not isinstance(zero_point, Sequence):
+                self.zero_point = int(zero_point)
+            else:
+                self.zero_point = [int(zp) for zp in zero_point]
 
-    def __repr__(self):
-        return self.name
+        self.q_dtype = q_dtype
+        self.np_dtype = np_dtype
+        self.qmin = qmin
+        self.qmax = qmax

--- a/mgeconvert/converter_ir/ir_transform.py
+++ b/mgeconvert/converter_ir/ir_transform.py
@@ -239,8 +239,6 @@ def _transpose_pattern_as_input(net):
             dtype=np.int32,
             np_data=np.array(op.pattern, dtype=np.int32),
             owner_opr=op,
-            q_type="int32",
-            np_dtype="int32",
             axis=None,
         )
         op.add_inp_tensors(perm_tensor)
@@ -268,8 +266,6 @@ def _pad_width_as_input(net):
             dtype=np.int32,
             np_data=padddings,
             owner_opr=op,
-            q_type="int32",
-            np_dtype="int32",
             axis=None,
         )
         op.add_inp_tensors(pad_tensor)
@@ -287,8 +283,6 @@ def _reduce_axis_as_input(net):
             dtype=np.int32,
             np_data=np.array(op.axis, dtype=np.int32),
             owner_opr=op,
-            q_type="int32",
-            np_dtype="int32",
             axis=None,
         )
         op.add_inp_tensors(axis_tensor)
@@ -332,8 +326,6 @@ def _make_padding(net: IRGraph):
                 dtype=np.int32,
                 owner_opr=None,
                 np_data=np_data,
-                q_type="int32",
-                np_dtype="int32",
                 axis=None,
             )
             net.add_tensor(new_tensor_id, pad_in_tensor)
@@ -393,8 +385,6 @@ def _deconv_shape_as_input(net: IRGraph):
             dtype=np.int32,
             owner_opr=op,
             np_data=np_data,
-            q_type="int32",
-            np_dtype="int32",
             axis=None,
         )
         shape_tensor = net.get_tensor(new_tensor_id, shape_symvar)
@@ -427,8 +417,6 @@ def _resize_params_as_input(net):
             shape=(2,),
             dtype=np.int32,
             np_data=np.array(op.out_size, dtype=np.int32),
-            q_type="int32",
-            np_dtype="int32",
             axis=None,
         )
         op.add_inp_tensors(out_size_tensor)
@@ -578,8 +566,6 @@ def _make_slice_as_inputs(net: IRGraph):
                 dtype=np.int32,
                 np_data=np.array(ret, dtype=np.int32),
                 owner_opr=op,  # pylint:disable=cell-var-from-loop
-                q_type="int32",
-                np_dtype="int32",
             )
             return ret
 

--- a/mgeconvert/frontend/tm_to_ir/op_generators/base.py
+++ b/mgeconvert/frontend/tm_to_ir/op_generators/base.py
@@ -67,7 +67,5 @@ class OpGenBase(ABC):
         for o in self.expr.outputs:
             t = self.resolver.get_ir_tensor(o, owner_opr=self.op)
             if is_qat:
-                t.scale = self.op.inp_tensors[0].scale
-                t.zero_point = self.op.inp_tensors[0].zero_point
-                t.q_dtype = self.op.inp_tensors[0].q_dtype
+                t.set_qparams_from_other_tensor(self.op.inp_tensors[0])
             self.op.add_out_tensors(t)

--- a/mgeconvert/frontend/tm_to_ir/op_generators/concat.py
+++ b/mgeconvert/frontend/tm_to_ir/op_generators/concat.py
@@ -52,10 +52,10 @@ class GenQConcatOpr(GenConcatOpr):
             self.module = expr.inputs[0].owner
         if hasattr(self.module.act_fake_quant, "get_qparams"):
             self.act_qparams = self.module.act_fake_quant.get_qparams()
-            self.act_dtype = self.act_qparams.dtype_meta.np_dtype_str
+            self.act_dtype = self.act_qparams.dtype_meta.name
         elif hasattr(self.module.act_observer, "get_qparams"):
             self.act_qparams = self.module.act_observer.get_qparams()
-            self.act_dtype = self.act_qparams.dtype_meta.np_dtype_str
+            self.act_dtype = self.act_qparams.dtype_meta.name
         else:
             logger.error("Observer and FakeQuantize do not have get_qparams().")
         super().__init__(expr, irgraph=irgraph)
@@ -63,10 +63,6 @@ class GenQConcatOpr(GenConcatOpr):
     def add_opr_out_tensors(self):
         for o in self.expr.outputs:
             t = self.resolver.get_ir_tensor(o, owner_opr=self.op)
-            t.set_qparams(
-                *self.resolver.resolve_qparams(
-                    self.act_qparams.scale, self.act_qparams.zero_point
-                )
-            )
+            t.set_qparams_from_mge_qparams(self.act_qparams)
             t.q_dtype = self.act_dtype
             self.op.add_out_tensors(t)

--- a/mgeconvert/frontend/tm_to_ir/op_generators/conv2d.py
+++ b/mgeconvert/frontend/tm_to_ir/op_generators/conv2d.py
@@ -106,14 +106,14 @@ class GenQConvBase(GenConvBase):
         conv_module = expr.inputs[0].owner
         if hasattr(conv_module.weight_fake_quant, "get_qparams"):
             self.weight_qparams = conv_module.weight_fake_quant.get_qparams()
-            self.weight_dtype = self.weight_qparams.dtype_meta.np_dtype_str
+            self.weight_dtype = self.weight_qparams.dtype_meta.name
             self.act_qparams = conv_module.act_fake_quant.get_qparams()
-            self.act_dtype = self.act_qparams.dtype_meta.np_dtype_str
+            self.act_dtype = self.act_qparams.dtype_meta.name
         elif hasattr(conv_module.weight_observer, "get_qparams"):
             self.weight_qparams = conv_module.weight_observer.get_qparams()
-            self.weight_dtype = self.weight_qparams.dtype_meta.np_dtype_str
+            self.weight_dtype = self.weight_qparams.dtype_meta.name
             self.act_qparams = conv_module.act_observer.get_qparams()
-            self.act_dtype = self.act_qparams.dtype_meta.np_dtype_str
+            self.act_dtype = self.act_qparams.dtype_meta.name
         else:
             logger.error("Observer and FakeQuantize do not have get_qparams().")
         super().__init__(expr, irgraph, op_cls)
@@ -121,11 +121,7 @@ class GenQConvBase(GenConvBase):
     def add_opr_out_tensors(self):
         for o in self.expr.outputs:
             out_tensor = self.resolver.get_ir_tensor(o, self.op)
-            out_tensor.set_qparams(
-                *self.resolver.resolve_qparams(
-                    self.act_qparams.scale, self.act_qparams.zero_point
-                )
-            )
+            out_tensor.set_qparams_from_mge_qparams(self.act_qparams)
             out_tensor.q_dtype = self.act_dtype
             self.op.add_out_tensors(out_tensor)
 
@@ -137,11 +133,7 @@ class GenQConvBase(GenConvBase):
                 name=self.expr.inputs[0]._name + "_weight",
                 axis_order=weight_format,
             )
-            weight_tensor.set_qparams(
-                *self.resolver.resolve_qparams(
-                    self.weight_qparams.scale, self.weight_qparams.zero_point
-                )
-            )
+            weight_tensor.set_qparams_from_mge_qparams(self.weight_qparams)
             weight_tensor.q_dtype = self.weight_dtype
             self.op.add_inp_tensors(weight_tensor)
 
@@ -150,9 +142,11 @@ class GenQConvBase(GenConvBase):
                 self.bias, user_opr=self.op, name=self.expr.inputs[0]._name + "_bias"
             )
             bias_tensor.set_qparams(
-                self.op.inp_tensors[0].scale * weight_tensor.scale, 0
+                scale=self.op.inp_tensors[0].scale * weight_tensor.scale,
+                zero_point=0,
+                q_dtype="int32",
+                np_dtype="int32",
             )
-            bias_tensor.q_dtype = "int32"
             self.op.add_inp_tensors(bias_tensor)
 
 

--- a/mgeconvert/frontend/tm_to_ir/op_generators/conv_bn2d.py
+++ b/mgeconvert/frontend/tm_to_ir/op_generators/conv_bn2d.py
@@ -83,14 +83,14 @@ class GenQConvBnBase(GenConvBnBase):
         conv_module = expr.inputs[0].owner
         if hasattr(conv_module.weight_fake_quant, "get_qparams"):
             self.weight_qparams = conv_module.weight_fake_quant.get_qparams()
-            self.weight_dtype = self.weight_qparams.dtype_meta.np_dtype_str
+            self.weight_dtype = self.weight_qparams.dtype_meta.name
             self.act_qparams = conv_module.act_fake_quant.get_qparams()
-            self.act_dtype = self.act_qparams.dtype_meta.np_dtype_str
+            self.act_dtype = self.act_qparams.dtype_meta.name
         elif hasattr(conv_module.weight_observer, "get_qparams"):
             self.weight_qparams = conv_module.weight_observer.get_qparams()
-            self.weight_dtype = self.weight_qparams.dtype_meta.np_dtype_str
+            self.weight_dtype = self.weight_qparams.dtype_meta.name
             self.act_qparams = conv_module.act_observer.get_qparams()
-            self.act_dtype = self.act_qparams.dtype_meta.np_dtype_str
+            self.act_dtype = self.act_qparams.dtype_meta.name
         else:
             logger.error("Observer and FakeQuantize do not have get_qparams().")
         super().__init__(expr, irgraph, op_cls)
@@ -98,11 +98,7 @@ class GenQConvBnBase(GenConvBnBase):
     def add_opr_out_tensors(self):
         for o in self.expr.outputs:
             out_tensor = self.resolver.get_ir_tensor(o, self.op)
-            out_tensor.set_qparams(
-                *self.resolver.resolve_qparams(
-                    self.act_qparams.scale, self.act_qparams.zero_point
-                )
-            )
+            out_tensor.set_qparams_from_mge_qparams(self.act_qparams)
             out_tensor.q_dtype = self.act_dtype
             self.op.add_out_tensors(out_tensor)
 
@@ -114,12 +110,7 @@ class GenQConvBnBase(GenConvBnBase):
                 name=self.expr.inputs[0]._name + "_weight",
                 axis_order=weight_format,
             )
-            weight_tensor.set_qparams(
-                *self.resolver.resolve_qparams(
-                    self.weight_qparams.scale, self.weight_qparams.zero_point
-                )
-            )
-            weight_tensor.q_dtype = self.weight_dtype
+            weight_tensor.set_qparams_from_mge_qparams(self.weight_qparams)
             self.op.add_inp_tensors(weight_tensor)
 
         if self.bias is not None:
@@ -127,9 +118,11 @@ class GenQConvBnBase(GenConvBnBase):
                 self.bias, user_opr=self.op, name=self.expr.inputs[0]._name + "_bias"
             )
             bias_tensor.set_qparams(
-                self.op.inp_tensors[0].scale * weight_tensor.scale, 0
+                scale=self.op.inp_tensors[0].scale * weight_tensor.scale,
+                zero_point=0,
+                q_dtype="int32",
+                np_dtype="int32",
             )
-            bias_tensor.q_dtype = "int32"
             self.op.add_inp_tensors(bias_tensor)
 
 

--- a/mgeconvert/frontend/tm_to_ir/op_generators/elemwise.py
+++ b/mgeconvert/frontend/tm_to_ir/op_generators/elemwise.py
@@ -94,9 +94,7 @@ class GenElemwiseOpr(OpGenBase, ABC):
             and self.op.inp_tensors[0].scale is not None
         ):
             for o in self.op.out_tensors:
-                o.scale = self.op.inp_tensors[0].scale
-                o.zero_point = self.op.inp_tensors[0].zero_point
-                o.dtype = self.op.inp_tensors[0].dtype
+                o.set_qparams_from_other_tensor(self.op.inp_tensors[0])
             # set dtype for const value
 
 
@@ -283,9 +281,6 @@ def get_elemwise_op(expr, net):
         else:
             qparams = module.act_observer.get_qparams()
         for o in op_gen.get_opr().out_tensors:
+            o.set_qparams_from_mge_qparams(qparams)
             o.scale = float(qparams.scale) if method != "sigmoid" else 1 / 256.0
-            o.zero_point = (
-                int(qparams.zero_point) if qparams.zero_point is not None else None
-            )
-            o.q_dtype = qparams.dtype_meta.np_dtype_str
     return op_gen

--- a/mgeconvert/frontend/tm_to_ir/op_generators/subtensor.py
+++ b/mgeconvert/frontend/tm_to_ir/op_generators/subtensor.py
@@ -75,3 +75,9 @@ class GenGetSubtensorOpr(OpGenBase):
         inp_tensor = self.resolver.get_ir_tensor(inp, user_opr=self.op)
         self.op.add_inp_tensors(inp_tensor)
         self.add_opr_out_tensors()
+        if (
+            hasattr(self.op.inp_tensors[0], "scale")
+            and self.op.inp_tensors[0].scale is not None
+        ):
+            for o in self.op.out_tensors:
+                o.set_qparams_from_other_tensor(self.op.inp_tensors[0])

--- a/mgeconvert/frontend/tm_to_ir/pattern_utils.py
+++ b/mgeconvert/frontend/tm_to_ir/pattern_utils.py
@@ -61,7 +61,11 @@ class InputNode:
 
 def register_pattern(pattern, default_dict: OrderedDict):
     def insert(func):
-        default_dict[pattern] = func
+        if isinstance(pattern, list):
+            for p in pattern:
+                default_dict[p] = func
+        else:
+            default_dict[pattern] = func
         return func
 
     return insert

--- a/mgeconvert/frontend/tm_to_ir/qat_pattern.py
+++ b/mgeconvert/frontend/tm_to_ir/qat_pattern.py
@@ -118,6 +118,13 @@ pat_conv = (
     MatchAnyNode,
 )
 
+pat_deconv = (
+    QATModule._apply_fakequant_with_observer,
+    MatchAnyNode,
+    (F.nn.conv_transpose2d, InputNode, QATModule._apply_fakequant_with_observer),
+    MatchAnyNode,
+)
+
 pat_deconv_relu = (
     QATModule._apply_fakequant_with_observer,
     MatchAnyNode,
@@ -168,6 +175,13 @@ def qat_conv(module, expr, call_expr, net, _):
     return op
 
 
+@register_fusion_pattern(pat_deconv)
+def qat_deconv(module, expr, call_expr, net, _):
+    conv = expr.inputs[1].expr
+    op = gen_qat_conv_opr(module, conv, call_expr, net, is_deconv=True)
+    return op
+
+
 @register_fusion_pattern(pat_deconv_bias)
 def qat_deconv_bias(module, expr, call_expr, irgraph, _):
     conv = expr.inputs[1].expr
@@ -206,6 +220,7 @@ MATCH_RULE[QATModule._apply_fakequant_with_observer] = [
     pat_deconv_relu,
     pat_conv_relu,
     pat_conv,
+    pat_deconv,
     pat_deconv_bias,
 ]
 

--- a/test/mge/test_tflite.py
+++ b/test/mge/test_tflite.py
@@ -157,7 +157,13 @@ def test_slice():
     net = SubtensorOpr()
     mge_result = dump_mge_model(net, net.data, tmp_file)
     _test_convert_result(
-        net.data, tmp_file, mge_result, max_error, nhwc=False, nhwc2=False
+        net.data,
+        tmp_file,
+        mge_result,
+        max_error,
+        nhwc=False,
+        nhwc2=False,
+        disable_nhwc=True,
     )
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -245,6 +245,20 @@ class SubtensorOpr(M.Module):
         return x
 
 
+class NCHW_SubtensorOpr(M.Module):
+    def __init__(self, fix_batch=False):
+        super().__init__()
+        self.fix_batch = fix_batch
+        self.data = np.random.random((5, 10, 20, 20)).astype(np.float32)
+
+    def forward(self, x):
+        if self.fix_batch:
+            x = x[:, 4:8, 4:9, 2]
+        else:
+            x = x[1:3, 4:8, 4:9, 2]
+        return x
+
+
 class TransposeOpr(M.Module):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
修复转换器部分bug

1. 重构获取量化类型信息的代码， 从QuantDtypeMeta获取量化信息， 类型名（导出量化参数json时使用）/ 对应np dtype（对float参数quantize时使用)/ qmin/ qmax

bug 修复：
1. 修复 GetSubtensor/Squeeze nhwc时的转换， nhwc情况下把GetSubtensor start/end/step tensor 和Squeeze squeeze_ndim 从 nchw转成nhwc （主要修改tflite_op.py 文件)
2. 修复 SLICE_PARAMS_AS_INPUTS_AND_MAKE_SQUEEZE Transformation, GetSubtensor squeeze_axis 为空时不再添加SqueezeOpr （修改ir_transformation.py)
3. 修复FUSE_ACTIVATION Transformation,  Conv -> tensor A -> Relu 这种情况如果Tensor A是网络输出的情况下有bug， 删除tensor A未对应修改网络输出 (修改ir_transformation.py)
4. qat_pattern 增加新pattern （pat_conv_bias_relu_1）匹配用户自定义ConvBiasRelu Module（修改qat_pattern.py)

@CaoWGG @daisycx  please kindly review, thx!