### PR TITLE
fix ci

### DIFF
--- a/ci/requires-test.txt
+++ b/ci/requires-test.txt
@@ -1,3 +1,4 @@
 numpy>=1.17
 onnx==1.7.0
 onnxoptimizer
+onnx-simplifier==0.3.6


### PR DESCRIPTION
跑ci时装的新版本onnx-simplifier 导致 onnx_to_mge时报错，固定onnx-simplifier版本