### PR TITLE
Support bias int64

### DIFF
--- a/bin/convert
+++ b/bin/convert
@@ -94,7 +94,7 @@ complete_str = """_mgeconvert(){
                     return
                     ;;
                 tracedmodule_to_tflite)
-                    words="-i --input -o --output --input_data_type --input_scales --input_zero_points --require_quantize --param_fake_quant --quantize_file_path --graph_name --mtk --end_point  --outspec --remove_relu --prefer_same_pad_mode"
+                    words="-i --input -o --output --input_data_type --input_scales --input_zero_points --require_quantize --param_fake_quant --quantize_file_path --graph_name --mtk --end_point  --outspec --remove_relu --prefer_same_pad_mode --use_int64_bias"
                     COMPREPLY=( $(compgen -W "$words" -- $word) )
                     return
                     ;;
@@ -397,6 +397,7 @@ def init(subparsers):
                     outspec=args.outspec,
                     remove_relu=args.remove_relu,
                     prefer_same_pad_mode=args.prefer_same_pad_mode,
+                    use_int64_bias=args.use_int64_bias,
                 )
             else:
                 mgeconvert.mge_to_tflite(
@@ -406,6 +407,7 @@ def init(subparsers):
                     mtk=args.mtk,
                     outspec=args.outspec,
                     prefer_same_pad_mode=args.prefer_same_pad_mode,
+                    use_int64_bias=args.use_int64_bias,
                 )
 
         def tflite_parser(subparsers):
@@ -486,6 +488,12 @@ def init(subparsers):
                 "--prefer_same_pad_mode",
                 action="store_true",
                 help="whether prefer to use SAME pad mode for conv op",
+            )
+
+            p.add_argument(
+                "--use_int64_bias",
+                action="store_true",
+                help="whether use int64 as dtype of bias",
             )
 
         tflite_parser(subparsers)

--- a/mgeconvert/backend/ir_to_tflite/tflite_op.py
+++ b/mgeconvert/backend/ir_to_tflite/tflite_op.py
@@ -233,6 +233,7 @@ mge2tflite_dtype_mapping = {
     "int8": TensorType.INT8,
     "int16": TensorType.INT16,
     "int32": TensorType.INT32,
+    "int64": TensorType.INT64,
     "qint8_narrow": TensorType.INT8,
 }
 

--- a/mgeconvert/converters/mge_to_tflite.py
+++ b/mgeconvert/converters/mge_to_tflite.py
@@ -24,6 +24,7 @@ def mge_to_tflite(
     disable_nhwc=False,
     outspec=None,
     prefer_same_pad_mode=False,
+    use_int64_bias=False,
 ):
     """
     Convert megengine model to TFLite,
@@ -69,6 +70,9 @@ def mge_to_tflite(
         set_platform("mtk")
         transformer_options.append(TransformerRule.DECONV_ADD_ZERO_BIAS,)
         transformer_options.append(TransformerRule.FUSE_FOR_DECONV_BIAS,)
+
+    if use_int64_bias:
+        transformer_options.append(TransformerRule.BIAS_ASTYPE_INT64)
 
     transformer = IRTransform(transformer_options)
     transformed_irgraph = transformer.transform(irgraph)

--- a/mgeconvert/converters/tm_to_tflite.py
+++ b/mgeconvert/converters/tm_to_tflite.py
@@ -39,6 +39,7 @@ def tracedmodule_to_tflite(
     remove_relu=False,
     prefer_same_pad_mode=False,
     disable_nhwc=False,
+    use_int64_bias=False,
 ):
     """
 	Convert traced model to TFLite,
@@ -89,6 +90,8 @@ def tracedmodule_to_tflite(
         transformer_options.append(TransformerRule.DECONV_ADD_ZERO_BIAS,)
     if remove_relu:
         transformer_options.append(TransformerRule.REMOVE_TFLITE_RELU,)
+    if use_int64_bias:
+        transformer_options.append(TransformerRule.BIAS_ASTYPE_INT64)
 
     transformer = IRTransform(transformer_options)
     transformed_irgraph = transformer.transform(irgraph)


### PR DESCRIPTION
支持转换tflite时把bias 设置成int64类型

用法， 调用api时添加 use_int64_bias = True 的参数， 或者使用命令时添加 --use_int64_bias