### PR TITLE
fix(tm): fix name issue of model with dequant stub

### DIFF
--- a/mgeconvert/frontend/tm_to_ir/tm_frontend.py
+++ b/mgeconvert/frontend/tm_to_ir/tm_frontend.py
@@ -131,9 +131,16 @@ class TM_FrontEnd:
                             else module.act_observer.get_qparams()
                         )
                         out_tensor.set_qparams_from_mge_qparams(qparams)
-                    elif isinstance(m.owner, (FloatQuantStub, FloatDequantStub)):
+                    elif isinstance(m.owner, FloatQuantStub):
                         module = m.owner
                         inp_tensor = self.tensor_resolver.get_ir_tensor(expr.inputs[1])
+                        self.irgraph.get_tensor(
+                            expr.outputs[0]._id, None, origin_tensor=inp_tensor
+                        )
+                    elif isinstance(m.owner, FloatDequantStub):
+                        module = m.owner
+                        inp_tensor = self.tensor_resolver.get_ir_tensor(expr.inputs[1])
+                        inp_tensor.name = expr.outputs[0]._name
                         self.irgraph.get_tensor(
                             expr.outputs[0]._id, None, origin_tensor=inp_tensor
                         )


### PR DESCRIPTION
input->dequantstub->output 删掉dequantstub时 output node的name 是 dequantstub输入的名字，和输入traced module不一致。